### PR TITLE
fixing next= parameter for register & login links in navbar

### DIFF
--- a/bibliotek/lendingLibrary/templates/lendingLibrary/base.html
+++ b/bibliotek/lendingLibrary/templates/lendingLibrary/base.html
@@ -690,8 +690,8 @@
             <a href="{% url 'lendingLibrary:register_login' %}?next=/">Login</a>
           {% else %}
             <a href="{% url 'lendingLibrary:index' %}">Home</a> |
-            <a href="{% url 'lendingLibrary:register_login' %}?next={{request.path}}#register_section">Register</a> |
-            <a href="{% url 'lendingLibrary:register_login' %}?next={{request.path}}">Login</a>
+            <a href="{% url 'lendingLibrary:register_login' %}?next={{request.path}}?{{request.GET.urlencode}}#register_section">Register</a> |
+            <a href="{% url 'lendingLibrary:register_login' %}?next={{request.path}}?{{request.GET.urlencode}}">Login</a>
           {% endif %}
         </span>
       {% else %}


### PR DESCRIPTION
changing next= link to include url args (like after a search, e.g. /search/?q=wagon